### PR TITLE
[BLDC] Revert PI setpoint reversal

### DIFF
--- a/control_loop/bldc/brushless_control_loop.cpp
+++ b/control_loop/bldc/brushless_control_loop.cpp
@@ -380,8 +380,8 @@ void BrushlessControlLoop::run_foc(float speed, utime_t current_time_us, utime_t
 
         // Run the PI controller
         // The below hack for speed is kinda hacky and should be reverted lol
-        const float q_voltage_delta = pid_q_current_.calculate(speed * params_->foc_params.speed_to_iq_gain, i_quadrature_);
-        const float d_voltage_delta = pid_d_current_.calculate(i_d_reference_, i_direct_);
+        const float q_voltage_delta = pid_q_current_.calculate(i_quadrature_, speed * params_->foc_params.speed_to_iq_gain);
+        const float d_voltage_delta = pid_d_current_.calculate(i_direct_, i_d_reference_);
         V_quadrature_ += q_voltage_delta;
         V_direct_ += d_voltage_delta;
         // Limit the Vd and Vq by first calculating the modulus of the vector

--- a/control_loop/bldc/brushless_foc.cpp
+++ b/control_loop/bldc/brushless_foc.cpp
@@ -42,10 +42,12 @@ FocDutyCycleResult determine_inverter_duty_cycles_foc(float theta, float Vdirect
                 duty_cycle_w_h = 0.0f;
                 break;
             }
-            // Not fully sure why the scale is required, see https://github.com/sahil-kale/basilisk-actuator-control-lib/issues/26
-            duty_cycle_u_h = inverse_clarke_transform.a * (3.0f / 2.0f) / (bus_voltage);
-            duty_cycle_v_h = inverse_clarke_transform.b * (3.0f / 2.0f) / (bus_voltage);
-            duty_cycle_w_h = inverse_clarke_transform.c * (3.0f / 2.0f) / (bus_voltage);
+            // The inverse clarke transforms produce a line-line voltage that is both positive
+            // and negative. We can provide +- bus_voltage/2 to the high side and the low side
+            // and should scale the duty cycle accordingly
+            duty_cycle_u_h = inverse_clarke_transform.a / (bus_voltage / 2.0f);
+            duty_cycle_v_h = inverse_clarke_transform.b / (bus_voltage / 2.0f);
+            duty_cycle_w_h = inverse_clarke_transform.c / (bus_voltage / 2.0f);
 
             // Duty cycles can be between -1 and 1, and those should linearly map to 0 -> 1
             duty_cycle_u_h = (duty_cycle_u_h + max_duty_cycle) / (max_duty_cycle * 2.0f);


### PR DESCRIPTION
Found bug in simulink model where GND and OUT were reversed. Also fully addressed the bus voltage duty cycle scaling for sine PWM modes