### PR TITLE
[Rotor Estimator] Remove 3/2 multiplier for stator inductance

### DIFF
--- a/control_loop/bldc/rotor_estimator/rotor_estimator.cpp
+++ b/control_loop/bldc/rotor_estimator/rotor_estimator.cpp
@@ -317,7 +317,9 @@ app_hal_status_E SensorlessRotorFluxObserver::update(const EstimatorInputs& inpu
 
         // Update the phase resistance and inductance values to use the equivalent Alpha-Beta parameters
         const float stator_resistance = inputs.phase_resistance * 3.0f / 2.0f;
-        const float stator_inductance = inputs.phase_inductance * 3.0f / 2.0f;
+        const float stator_inductance =
+            inputs.phase_inductance;  // We are assuming phase inductance = Ld and Ld = Lq. This might be wrong
+                                      // (https://github.com/sahil-kale/basilisk-actuator-control-lib/issues/81)
 
         // Clarke transform the current
         math::alpha_beta_t i_ab = math::clarke_transform(inputs.phase_current.u, inputs.phase_current.v, inputs.phase_current.w);


### PR DESCRIPTION
https://github.com/sahil-kale/basilisk-actuator-control-lib/issues/81